### PR TITLE
support creating `arrow_udf_flight::Client` from `FlightServiceClient`

### DIFF
--- a/arrow-udf-flight/src/lib.rs
+++ b/arrow-udf-flight/src/lib.rs
@@ -44,10 +44,7 @@ impl Client {
     }
 
     /// Create a new client.
-    pub async fn new(channel: Channel) -> Result<Self> {
-        let mut client = FlightServiceClient::new(channel);
-
-        // get protocol version in server
+    pub async fn new(mut client: FlightServiceClient<Channel>) -> Result<Self> {
         let protocol_version = match client.do_action(Action::new("protocol_version", "")).await {
             // if `do_action` is not implemented, assume protocol version is 1
             Err(_) => 1,

--- a/arrow-udf-flight/src/lib.rs
+++ b/arrow-udf-flight/src/lib.rs
@@ -45,6 +45,7 @@ impl Client {
 
     /// Create a new client.
     pub async fn new(mut client: FlightServiceClient<Channel>) -> Result<Self> {
+        // get protocol version in server
         let protocol_version = match client.do_action(Action::new("protocol_version", "")).await {
             // if `do_action` is not implemented, assume protocol version is 1
             Err(_) => 1,

--- a/arrow-udf-flight/src/lib.rs
+++ b/arrow-udf-flight/src/lib.rs
@@ -40,7 +40,7 @@ impl Client {
         let conn = tonic::transport::Endpoint::new(addr.into())?
             .connect()
             .await?;
-        Self::new(conn).await
+        Self::new(FlightServiceClient::new(conn)).await
     }
 
     /// Create a new client.


### PR DESCRIPTION
Seems we need to allow user of `arrow_udf_flight::Client` to change the max message size of the underlying tonic client.