### PR TITLE
fix `as_primitive` not found error when building Rust UDF

### DIFF
--- a/arrow-udf-macros/CHANGELOG.md
+++ b/arrow-udf-macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1] - 2024-10-08
+
+### Fixed
+
+- Fix complilation of Rust UDF using primitive array data types.

--- a/arrow-udf-macros/Cargo.toml
+++ b/arrow-udf-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-macros"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Procedural macros for generating Arrow functions."
 repository = "https://github.com/risingwavelabs/arrow-udf"

--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -418,6 +418,7 @@ impl FunctionAttr {
             use ::arrow_udf::codegen::arrow_array::RecordBatch;
             use ::arrow_udf::codegen::arrow_array::array::*;
             use ::arrow_udf::codegen::arrow_array::builder::*;
+            use ::arrow_udf::codegen::arrow_array::cast::AsArray;
             use ::arrow_udf::codegen::arrow_schema::{Schema, SchemaRef, Field, DataType, IntervalUnit, TimeUnit};
             use ::arrow_udf::codegen::arrow_arith;
             use ::arrow_udf::codegen::arrow_schema;

--- a/arrow-udf-wasm/CHANGELOG.md
+++ b/arrow-udf-wasm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix complilation of Rust UDF using primitive array data types.
+
 ## [0.3.0] - 2024-09-19
 
 ### Fixed

--- a/arrow-udf-wasm/CHANGELOG.md
+++ b/arrow-udf-wasm/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix complilation of Rust UDF using primitive array data types.
-
 ## [0.3.0] - 2024-09-19
 
 ### Fixed

--- a/arrow-udf/tests/tests.rs
+++ b/arrow-udf/tests/tests.rs
@@ -16,7 +16,6 @@ use std::iter::Sum;
 use std::ops::{Add, Neg};
 use std::sync::Arc;
 
-use arrow_array::cast::AsArray;
 use arrow_array::temporal_conversions::time_to_time64us;
 use arrow_array::types::{Date32Type, Int32Type};
 use arrow_array::*;


### PR DESCRIPTION
fix https://github.com/risingwavelabs/risingwave/issues/18797