### PR TITLE
feat: use forked genawaiter

### DIFF
--- a/arrow-udf-example/Cargo.toml
+++ b/arrow-udf-example/Cargo.toml
@@ -9,4 +9,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow-udf = { path = "../arrow-udf" }
-genawaiter = "0.99"

--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -436,7 +436,7 @@ impl FunctionAttr {
                     -> ::arrow_udf::Result<Box<dyn Iterator<Item = ::arrow_udf::codegen::arrow_array::RecordBatch> + 'a>>
                 {
                     const BATCH_SIZE: usize = 1024;
-                    use ::arrow_udf::codegen::genawaiter::{rc::gen, yield_};
+                    use ::arrow_udf::codegen::genawaiter2::{self, rc::gen, yield_};
                     use ::arrow_udf::codegen::arrow_array::array::*;
                     #downcast_arrays
                     Ok(Box::new(gen!({ #body }).into_iter()))

--- a/arrow-udf-wasm/CHANGELOG.md
+++ b/arrow-udf-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-12-23
+
+### Changed
+
+- Replace unmaintained `genawaiter` with forked version `genawaiter2`.
+
 ## [0.4.0] - 2024-11-15
 
 - Rename target `wasm32-wasi` to `wasm32-wasip1`.

--- a/arrow-udf-wasm/Cargo.toml
+++ b/arrow-udf-wasm/Cargo.toml
@@ -19,7 +19,7 @@ arrow-ipc = { workspace = true }
 arrow-schema = { workspace = true }
 async-trait = "0.1"
 base64 = "0.22"
-genawaiter = "0.99"
+genawaiter2 = "0.100.1"
 once_cell = "1"
 tempfile = { version = "3", optional = true }
 wasi-common = "27"

--- a/arrow-udf-wasm/Cargo.toml
+++ b/arrow-udf-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-wasm"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "WebAssembly runtime for Arrow UDFs."
 repository = "https://github.com/risingwavelabs/arrow-udf"

--- a/arrow-udf-wasm/src/build.rs
+++ b/arrow-udf-wasm/src/build.rs
@@ -99,9 +99,6 @@ crate-type = ["cdylib"]
 [dependencies.arrow-udf]
 version = "{}"
 
-[dependencies.genawaiter]
-version = "0.99"
-
 {}"#,
         opts.arrow_udf_version.as_deref().unwrap_or("0.2"),
         opts.manifest

--- a/arrow-udf-wasm/src/lib.rs
+++ b/arrow-udf-wasm/src/lib.rs
@@ -214,7 +214,7 @@ impl Runtime {
         name: &'a str,
         input: &'a RecordBatch,
     ) -> Result<impl Iterator<Item = Result<RecordBatch>> + 'a> {
-        use genawaiter::{sync::gen, yield_};
+        use genawaiter2::{sync::gen, yield_};
         if !self.functions.contains(name) {
             bail!("function not found: {name}");
         }

--- a/arrow-udf/CHANGELOG.md
+++ b/arrow-udf/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-12-23
+
+### Changed
+
+- Now users of the `arrow-udf::function` macro don't need to add `genawaiter` as a dependency.
+
 ## [0.5.0] - 2024-10-10
 
 ### Fixed

--- a/arrow-udf/Cargo.toml
+++ b/arrow-udf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "User-defined function framework for arrow-rs."
 repository = "https://github.com/risingwavelabs/arrow-udf"
@@ -14,8 +14,6 @@ global_registry = ["linkme"]
 [dependencies]
 arrow-arith.workspace = true
 arrow-array.workspace = true
-arrow-buffer.workspace = true
-arrow-data.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
 arrow-udf-macros = { version = "0.4.1", path = "../arrow-udf-macros" }
@@ -25,7 +23,6 @@ linkme = { version = "0.3", optional = true }
 once_cell = "1"
 rust_decimal = "1"
 serde_json = "1"
-thiserror = "1"
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }

--- a/arrow-udf/Cargo.toml
+++ b/arrow-udf/Cargo.toml
@@ -20,7 +20,7 @@ arrow-ipc.workspace = true
 arrow-schema.workspace = true
 arrow-udf-macros = { version = "0.4.1", path = "../arrow-udf-macros" }
 chrono = { version = "0.4", default-features = false }
-genawaiter = "0.99"
+genawaiter2 = "0.100.1"
 linkme = { version = "0.3", optional = true }
 once_cell = "1"
 rust_decimal = "1"

--- a/arrow-udf/src/lib.rs
+++ b/arrow-udf/src/lib.rs
@@ -40,7 +40,7 @@ pub mod codegen {
     pub use arrow_array;
     pub use arrow_schema;
     pub use chrono;
-    pub use genawaiter;
+    pub use genawaiter2;
     #[cfg(feature = "global_registry")]
     pub use linkme;
     pub use once_cell;


### PR DESCRIPTION

    
* `genawaiter` is unmaintained. Forked and published as `genawaiter2` https://github.com/arrow-udf/genawaiter  https://crates.io/search?q=genawaiter2
* now users of arrow-udf macro doesn't need to add `genawaiter` in their dependencies. Core change: https://github.com/arrow-udf/genawaiter/pull/2
    