### PR TITLE
fix: results out-of-order when `io_threads` is set larger than 1

### DIFF
--- a/arrow-udf-flight/python/CHANGELOG.md
+++ b/arrow-udf-flight/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - todo
+
+### Fixed
+
+- Fix results out-of-order issue when `io_threads` is set larger than `1`. This is a CRITICAL fix. We highly encourage every user to upgrade.
+
 ## [0.2.1] - 2024-05-07
 
 ### Fixed

--- a/arrow-udf-flight/python/arrow_udf/__init__.py
+++ b/arrow-udf-flight/python/arrow_udf/__init__.py
@@ -68,22 +68,26 @@ class ScalarFunction(UserDefinedFunction):
         # parse value from json string for jsonb columns
         inputs = [[v.as_py() for v in array] for array in batch]
 
+        # evaluate the function for each row
         if self._executor is not None:
-            # evaluate the function for each row
-            tasks = [
-                self._executor.submit(self._func, *[col[i] for col in inputs])
-                for i in range(batch.num_rows)
-            ]
-            column = [
-                future.result() for future in concurrent.futures.as_completed(tasks)
-            ]
+            # run in executor concurrently
+            results = list(
+                self._executor.map(
+                    lambda args: self._func(*args),  # manual `starmap`
+                    (
+                        # converts column-based inputs to rows
+                        (col[i] for col in inputs)
+                        for i in range(batch.num_rows)
+                    ),
+                )
+            )
         else:
-            # evaluate the function for each row
-            column = [
+            # run sequentially
+            results = [
                 self.eval(*[col[i] for col in inputs]) for i in range(batch.num_rows)
             ]
 
-        array = _to_arrow_array(column, self._result_schema.types[0])
+        array = _to_arrow_array(results, self._result_schema.types[0])
 
         yield pa.RecordBatch.from_arrays([array], schema=self._result_schema)
 

--- a/arrow-udf-flight/python/arrow_udf/__init__.py
+++ b/arrow-udf-flight/python/arrow_udf/__init__.py
@@ -76,7 +76,7 @@ class ScalarFunction(UserDefinedFunction):
                     lambda args: self._func(*args),  # manual `starmap`
                     (
                         # converts column-based inputs to rows
-                        (col[i] for col in inputs)
+                        [col[i] for col in inputs]
                         for i in range(batch.num_rows)
                     ),
                 )

--- a/arrow-udf-flight/python/pyproject.toml
+++ b/arrow-udf-flight/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arrow-udf"
-version = "0.2.1"
+version = "0.2.2"
 authors = [{ name = "RisingWave Labs" }]
 description = "A user-defined function framework for Apache Arrow"
 readme = "README.md"


### PR DESCRIPTION
In previous version we use [`submit`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.submit) + [`as_completed`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.as_completed) to spawn tasks and collect results. However, `as_completed` doesn't return results in the order of input futures. This led to a critical bug that the results can be totally wrong.

This PR uses [`map`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.map) instead. Unit tests are also updated to check the correctness of results.

I think all old versions should be yanked.