### PR TITLE
feat: introduce `add_function` method to WASM `Runtime`

### DIFF
--- a/arrow-udf-wasm/CHANGELOG.md
+++ b/arrow-udf-wasm/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `Runtime::functions` and `Runtime::find_function_by_inlined_signature` methods. Please use the new `Runtime::add_function` instead.
+
+### Added
+
+- Add `Runtime::add_function` method to register UDFs. This method accepts function name, argument types and return types, and find the corresponding exported function in the WASM binary. This unifies the usage of WASM UDF runtime and Python/JS UDF runtime.
+
 ## [0.4.1] - 2024-12-23
 
 ### Changed

--- a/arrow-udf-wasm/CHANGELOG.md
+++ b/arrow-udf-wasm/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Remove `Runtime::functions` and `Runtime::find_function_by_inlined_signature` methods. Please use the new `Runtime::add_function` instead.
+- Rename `Runtime::functions` to `Runtime::wasm_exported_functions`.
+- Remove `Runtime::find_function_by_inlined_signature` methods.
+- Change the semantic of `name` argument for `Runtime::call` and `Runtime::call_table_function` to the name registered with `Runtime::add_function`.
 
 ### Added
 

--- a/arrow-udf-wasm/Cargo.toml
+++ b/arrow-udf-wasm/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = "1"
 tempfile = { version = "3", optional = true }
 wasi-common = "27"
 wasmtime = "27"
+itertools = "0.14"
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }

--- a/arrow-udf-wasm/src/lib.rs
+++ b/arrow-udf-wasm/src/lib.rs
@@ -136,11 +136,6 @@ impl Runtime {
         })
     }
 
-    /// Return available WASM functions.
-    pub fn wasm_exported_functions(&self) -> impl Iterator<Item = &str> {
-        self.wasm_exported_functions.iter().map(|s| s.as_str())
-    }
-
     /// Return available WASM types.
     pub fn types(&self) -> impl Iterator<Item = (&str, &str)> {
         self.types.iter().map(|(k, v)| (k.as_str(), v.as_str()))
@@ -184,7 +179,7 @@ impl Runtime {
     /// input = "keyvalue(string, string) -> struct<key:string,value:string>"
     /// output = "keyvalue(string, string) -> struct KeyValue"
     /// ```
-    pub fn find_function_by_inlined_signature(&self, s: &str) -> Option<&str> {
+    fn find_function_by_inlined_signature(&self, s: &str) -> Option<&str> {
         self.wasm_exported_functions
             .iter()
             .find(|f| self.inline_types(f) == s)

--- a/arrow-udf-wasm/src/lib.rs
+++ b/arrow-udf-wasm/src/lib.rs
@@ -54,23 +54,6 @@ pub struct Config {
     pub file_size_limit: Option<usize>,
 }
 
-struct Instance {
-    // extern "C" fn(len: usize, align: usize) -> *mut u8
-    alloc: TypedFunc<(u32, u32), u32>,
-    // extern "C" fn(ptr: *mut u8, len: usize, align: usize)
-    dealloc: TypedFunc<(u32, u32, u32), ()>,
-    // extern "C" fn(iter: *mut RecordBatchIter, out: *mut CSlice)
-    record_batch_iterator_next: TypedFunc<(u32, u32), ()>,
-    // extern "C" fn(iter: *mut RecordBatchIter)
-    record_batch_iterator_drop: TypedFunc<u32, ()>,
-    // extern "C" fn(ptr: *const u8, len: usize, out: *mut CSlice) -> i32
-    functions: HashMap<String, TypedFunc<(u32, u32, u32), i32>>,
-    memory: Memory,
-    store: Store<(WasiCtx, StoreLimits)>,
-    stdout: RamFileRef,
-    stderr: RamFileRef,
-}
-
 impl Debug for Runtime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Runtime")
@@ -246,6 +229,23 @@ impl Runtime {
         })
         .into_iter())
     }
+}
+
+struct Instance {
+    // extern "C" fn(len: usize, align: usize) -> *mut u8
+    alloc: TypedFunc<(u32, u32), u32>,
+    // extern "C" fn(ptr: *mut u8, len: usize, align: usize)
+    dealloc: TypedFunc<(u32, u32, u32), ()>,
+    // extern "C" fn(iter: *mut RecordBatchIter, out: *mut CSlice)
+    record_batch_iterator_next: TypedFunc<(u32, u32), ()>,
+    // extern "C" fn(iter: *mut RecordBatchIter)
+    record_batch_iterator_drop: TypedFunc<u32, ()>,
+    // extern "C" fn(ptr: *const u8, len: usize, out: *mut CSlice) -> i32
+    functions: HashMap<String, TypedFunc<(u32, u32, u32), i32>>,
+    memory: Memory,
+    store: Store<(WasiCtx, StoreLimits)>,
+    stdout: RamFileRef,
+    stderr: RamFileRef,
 }
 
 impl Instance {

--- a/arrow-udf-wasm/src/lib.rs
+++ b/arrow-udf-wasm/src/lib.rs
@@ -136,6 +136,11 @@ impl Runtime {
         })
     }
 
+    /// Return available exported functions in WASM binary.
+    pub fn wasm_exported_functions(&self) -> impl Iterator<Item = &str> {
+        self.wasm_exported_functions.iter().map(String::as_str)
+    }
+
     /// Return available WASM types.
     pub fn types(&self) -> impl Iterator<Item = (&str, &str)> {
         self.types.iter().map(|(k, v)| (k.as_str(), v.as_str()))

--- a/arrow-udf-wasm/src/lib.rs
+++ b/arrow-udf-wasm/src/lib.rs
@@ -51,7 +51,7 @@ pub struct Runtime {
 }
 
 /// Configurations.
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct Config {
     /// Memory size limit in bytes.
@@ -64,12 +64,12 @@ impl Clone for Runtime {
     fn clone(&self) -> Self {
         Self {
             module: self.module.clone(), // this will share the immutable wasm binary
-            config: self.config.clone(),
+            config: self.config,
             wasm_exported_functions: self.wasm_exported_functions.clone(),
             types: self.types.clone(),
             functions: self.functions.clone(),
             instances: Default::default(), // just initialize a new instance pool
-            abi_version: self.abi_version.clone(),
+            abi_version: self.abi_version,
         }
     }
 }

--- a/arrow-udf-wasm/tests/build.rs
+++ b/arrow-udf-wasm/tests/build.rs
@@ -23,7 +23,9 @@ fn gcd(mut a: i32, mut b: i32) -> i32 {
     let binary = build(manifest, script).unwrap();
 
     let runtime = Runtime::new(&binary).unwrap();
-    assert!(runtime.functions().any(|f| f == "gcd(int4,int4)->int4"));
+    assert!(runtime
+        .wasm_exported_functions()
+        .any(|f| f == "gcd(int4,int4)->int4"));
 
     // build again with offline mode
     test_build_offline();
@@ -53,5 +55,7 @@ fn test_build_offline() {
     let binary = build_with(&opt).unwrap();
 
     let runtime = Runtime::new(&binary).unwrap();
-    assert!(runtime.functions().any(|f| f == "gcd(int4,int4)->int4"));
+    assert!(runtime
+        .wasm_exported_functions()
+        .any(|f| f == "gcd(int4,int4)->int4"));
 }


### PR DESCRIPTION
This PR adds the `arrow_udf_wasm::Runtime::add_function` method to unify the usage of WASM runtime and Python/JS runtime. This method accepts function name, argument types and return types, and finds the corresponding exported function in the WASM binary. After this, `#[function]` macro call can be simply viewed as something like an `export` keyword.

Since users no longer need to construct and find function signatures(identifiers) on their own, `Runtime::find_function_by_inlined_signature` is unpub-ed.

This is also a preparation for WASM UDAF support.