### PR TITLE
feat: Async JavaScript UDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We have benchmarked the performance of function calls in different environments.
 You can run the benchmarks with the following command:
 
 ```sh
-cargo bench --bench wasm
+cargo bench --bench bench
 ```
 
 Performance comparison of calling `gcd` on a chunk of 1024 rows:

--- a/arrow-udf-bench/Cargo.toml
+++ b/arrow-udf-bench/Cargo.toml
@@ -22,6 +22,7 @@ arrow-udf-python = { path = "../arrow-udf-python" }
 arrow-udf-wasm = { path = "../arrow-udf-wasm" }
 criterion = { version = "0.5", features = ["async_tokio", "async_futures"] }
 tokio = { workspace = true, features = ["rt"] }
+futures-util = "0.3"
 
 [[bench]]
 name = "bench"

--- a/arrow-udf-bench/README.md
+++ b/arrow-udf-bench/README.md
@@ -12,5 +12,9 @@ cargo build --release -p arrow-udf-example --target wasm32-wasip1
 2. Run the benchmarks:
 
 ```bash
+# Run all benchmarks
 cargo bench --bench bench
+
+# Run a specific benchmark
+cargo bench --bench bench js
 ```

--- a/arrow-udf-bench/README.md
+++ b/arrow-udf-bench/README.md
@@ -1,1 +1,16 @@
 # All-in-one Benchmark for Arrow UDFs
+
+## How to run
+
+1. Build the WebAssembly UDF example:
+
+```bash
+rustup target add wasm32-wasip1
+cargo build --release -p arrow-udf-example --target wasm32-wasip1
+```
+
+2. Run the benchmarks:
+
+```bash
+cargo bench --bench bench
+```

--- a/arrow-udf-js/Cargo.toml
+++ b/arrow-udf-js/Cargo.toml
@@ -14,7 +14,7 @@ arrow-array.workspace = true
 arrow-buffer.workspace = true
 arrow-schema.workspace = true
 atomic-time = "0.1"
-rquickjs = { version = "0.6", features = ["array-buffer", "parallel"] }
+rquickjs = { version = "0.8", features = ["array-buffer", "parallel", "futures"] }
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }

--- a/arrow-udf-js/Cargo.toml
+++ b/arrow-udf-js/Cargo.toml
@@ -14,7 +14,7 @@ arrow-array.workspace = true
 arrow-buffer.workspace = true
 arrow-schema.workspace = true
 atomic-time = "0.1"
-rquickjs = { version = "0.8", features = ["array-buffer", "parallel", "futures"] }
+rquickjs = { version = "0.6", features = ["array-buffer", "parallel", "futures"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["time", "test-util", "macros"] }
 

--- a/arrow-udf-js/Cargo.toml
+++ b/arrow-udf-js/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { version = "1", features = ["time", "test-util", "macros"] }
 arrow-cast = { workspace = true, features = ["prettyprint"] }
 arrow-select.workspace = true
 expect-test = "1"
+tokio-test = "0.4"

--- a/arrow-udf-js/Cargo.toml
+++ b/arrow-udf-js/Cargo.toml
@@ -15,6 +15,8 @@ arrow-buffer.workspace = true
 arrow-schema.workspace = true
 atomic-time = "0.1"
 rquickjs = { version = "0.8", features = ["array-buffer", "parallel", "futures"] }
+futures-util = "0.3"
+tokio = { version = "1", features = ["time", "test-util", "macros"] }
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }

--- a/arrow-udf-js/examples/js.rs
+++ b/arrow-udf-js/examples/js.rs
@@ -18,8 +18,9 @@ use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use arrow_udf_js::{CallMode, Runtime};
 
-fn main() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -37,6 +38,7 @@ fn main() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     runtime
@@ -52,6 +54,7 @@ fn main() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     println!("call gcd");
@@ -67,7 +70,7 @@ fn main() {
     )
     .unwrap();
 
-    let output = runtime.call("gcd", &input).unwrap();
+    let output = runtime.call("gcd", &input).await.unwrap();
 
     arrow_cast::pretty::print_batches(std::slice::from_ref(&input)).unwrap();
     arrow_cast::pretty::print_batches(std::slice::from_ref(&output)).unwrap();
@@ -79,7 +82,7 @@ fn main() {
     )
     .unwrap();
 
-    let output = runtime.call("fib", &input).unwrap();
+    let output = runtime.call("fib", &input).await.unwrap();
 
     arrow_cast::pretty::print_batches(std::slice::from_ref(&input)).unwrap();
     arrow_cast::pretty::print_batches(std::slice::from_ref(&output)).unwrap();

--- a/arrow-udf-js/examples/js.rs
+++ b/arrow-udf-js/examples/js.rs
@@ -37,6 +37,7 @@ async fn main() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -53,6 +54,7 @@ async fn main() {
                 return fib(x - 1) + fib(x - 2);
             }
             "#,
+            false,
         )
         .await
         .unwrap();

--- a/arrow-udf-js/src/doc_create_aggregate.txt
+++ b/arrow-udf-js/src/doc_create_aggregate.txt
@@ -5,7 +5,7 @@
 # use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch};
 # use std::sync::Arc;
 #
-# let mut runtime = Runtime::new().unwrap();
+# let mut runtime = Runtime::new().await.unwrap();
 # runtime.add_aggregate(
 #     "sum",
 #     DataType::Int32,
@@ -25,7 +25,9 @@
 #         return state1 + state2;
 #     }
 # "#,
+#     false,
 # )
+# .await
 # .unwrap();
 // suppose we have created a sum aggregate function
 // see the example in `add_aggregate`

--- a/arrow-udf-js/src/doc_create_function.txt
+++ b/arrow-udf-js/src/doc_create_function.txt
@@ -3,7 +3,7 @@
 # use arrow_schema::{DataType, Field, Schema};
 # use arrow_array::{RecordBatch, Int32Array};
 # use std::sync::Arc;
-# let mut runtime = Runtime::new().unwrap();
+# let mut runtime = Runtime::new().await.unwrap();
 # runtime
 #     .add_function(
 #         "gcd",
@@ -19,7 +19,9 @@
 #             return a;
 #         }
 # "#,
+#         false,
 #     )
+#     .await
 #     .unwrap();
 # runtime
 #     .add_function(
@@ -33,5 +35,7 @@
 #             }
 #         }
 # "#,
+#         false,
 #     )
+#     .await
 #     .unwrap();

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -25,11 +25,11 @@ use anyhow::{anyhow, bail, Context as _, Result};
 use arrow_array::{builder::Int32Builder, Array, ArrayRef, BooleanArray, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use futures_util::{FutureExt, Stream};
+use rquickjs::context::intrinsic::{All, Base};
 pub use rquickjs::runtime::MemoryUsage;
-use rquickjs::{async_with, Promise};
 use rquickjs::{
-    context::intrinsic::All, function::Args, module::Evaluated, AsyncContext, AsyncRuntime, Ctx,
-    FromJs, Module, Object, Persistent, Value,
+    async_with, function::Args, module::Evaluated, AsyncContext, AsyncRuntime, Ctx, FromJs, Module,
+    Object, Persistent, Promise, Value,
 };
 
 pub use self::into_field::IntoField;
@@ -138,7 +138,7 @@ impl Runtime {
     /// Create a new `Runtime`.
     pub async fn new() -> Result<Self> {
         let runtime = AsyncRuntime::new().context("failed to create quickjs runtime")?;
-        let context = AsyncContext::full(&runtime)
+        let context = AsyncContext::custom::<(Base, All)>(&runtime)
             .await
             .context("failed to create quickjs context")?;
 

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -106,9 +106,10 @@ struct Aggregate {
 }
 
 // This is required to pass `Function` and `Aggregate` from `async_with!` to outside.
+// SAFETY: We ensure the `JSRuntime` used in `async_with!` is same as the caller's.
+// The `parallel` feature of `rquickjs` is enabled, so itself can't ensure this.
 unsafe impl Send for Function {}
 unsafe impl Sync for Function {}
-
 unsafe impl Send for Aggregate {}
 unsafe impl Sync for Aggregate {}
 
@@ -137,7 +138,7 @@ impl Runtime {
     /// Create a new `Runtime`.
     pub async fn new() -> Result<Self> {
         let runtime = AsyncRuntime::new().context("failed to create quickjs runtime")?;
-        let context = AsyncContext::custom::<All>(&runtime)
+        let context = AsyncContext::full(&runtime)
             .await
             .context("failed to create quickjs context")?;
 

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -934,8 +934,8 @@ impl RecordBatchIter<'_> {
                 .context("failed to build arrow array from return values")?;
             Ok(Some(RecordBatch::try_new(
                 self.schema.clone(),
-                    vec![indexes, array],
-                )?))
+                vec![indexes, array],
+            )?))
         })
         .await
     }

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -824,6 +824,10 @@ impl Runtime {
         };
         result.map_err(|e| check_exception(e, ctx))
     }
+
+    pub fn context(&self) -> &AsyncContext {
+        &self.context
+    }
 }
 
 /// An iterator over the result of a table function.

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -46,6 +46,7 @@ async fn test_gcd() {
             DataType::Int32,
             CallMode::ReturnNullOnNullInput,
             js_code,
+            false,
         )
         .await
         .unwrap();
@@ -90,6 +91,7 @@ async fn test_to_string() {
             DataType::Utf8,
             CallMode::CalledOnNullInput,
             js_code,
+            false,
         )
         .await
         .unwrap();
@@ -125,6 +127,7 @@ async fn test_concat() {
                 return a.concat(b);
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -164,6 +167,7 @@ async fn test_json_array_access() {
                 return array[i];
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -203,6 +207,7 @@ async fn test_json_stringify() {
                 return JSON.stringify(object);
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -238,6 +243,7 @@ async fn test_binary_json_stringify() {
                 return object;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -271,6 +277,7 @@ async fn test_large_binary_json_stringify() {
                 return object;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -303,6 +310,7 @@ async fn test_large_string_as_string() {
                 return "string length is " + s.length;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -337,6 +345,7 @@ async fn test_decimal128() {
                 return a + b + BigDecimal('0.000001');
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -381,6 +390,7 @@ async fn test_decimal256() {
                 return a + b + BigDecimal('0.000001');
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -425,6 +435,7 @@ async fn test_decimal_add() {
                 return a + b;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -462,6 +473,7 @@ async fn test_timestamp_second_array() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -502,6 +514,7 @@ async fn test_timestamp_millisecond_array() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -542,6 +555,7 @@ async fn test_timestamp_microsecond_array() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -582,6 +596,7 @@ async fn test_timestamp_nanosecond_array() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -622,6 +637,7 @@ async fn test_date32_array() {
                 return a;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -658,6 +674,7 @@ async fn test_typed_array() {
                 return Object.prototype.toString.call(a);
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -717,6 +734,7 @@ async fn test_return_array() {
                 return [x];
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -756,6 +774,7 @@ async fn test_return_large_array() {
                 return [x, x+1, x+2];
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -799,6 +818,7 @@ async fn test_key_value() {
                 return {key, value};
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -833,6 +853,7 @@ async fn test_struct_to_json() {
                 return object;
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -889,6 +910,7 @@ async fn test_range() {
                 }
             }
             "#,
+            false,
         )
         .await
         .unwrap();
@@ -961,6 +983,7 @@ async fn test_weighted_avg() {
                 return state.sum / state.weight;
             }
 "#,
+            false,
         )
         .await
         .unwrap();
@@ -1043,6 +1066,7 @@ async fn test_timeout() {
             DataType::Int32,
             CallMode::ReturnNullOnNullInput,
             js_code,
+            false,
         )
         .await
         .unwrap();
@@ -1087,6 +1111,7 @@ async fn test_memory_limit() {
             DataType::Int32,
             CallMode::ReturnNullOnNullInput,
             js_code,
+            false,
         )
         .await
         .unwrap();
@@ -1127,6 +1152,7 @@ export function echo(x) {
     return x + "!"
 }
 "#,
+            false,
         )
         .await
         .unwrap();

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -26,9 +26,9 @@ use arrow_schema::{DataType, Field, Schema};
 use arrow_udf_js::{CallMode, Runtime};
 use expect_test::{expect, Expect};
 
-#[test]
-fn test_gcd() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_gcd() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     let js_code = r#"
         export function gcd(a, b) {
@@ -47,6 +47,7 @@ fn test_gcd() {
             CallMode::ReturnNullOnNullInput,
             js_code,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -58,7 +59,7 @@ fn test_gcd() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("gcd", &input).unwrap();
+    let output = runtime.call("gcd", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -71,9 +72,9 @@ fn test_gcd() {
     );
 }
 
-#[test]
-fn test_to_string() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_to_string() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     let js_code = r#"
         export function to_string(a) {
@@ -90,13 +91,14 @@ fn test_to_string() {
             CallMode::CalledOnNullInput,
             js_code,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
     let arg0 = Int32Array::from(vec![Some(5), None]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("to_string", &input).unwrap();
+    let output = runtime.call("to_string", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -109,9 +111,9 @@ fn test_to_string() {
     );
 }
 
-#[test]
-fn test_concat() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_concat() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -124,6 +126,7 @@ fn test_concat() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -135,7 +138,7 @@ fn test_concat() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("concat", &input).unwrap();
+    let output = runtime.call("concat", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -147,9 +150,9 @@ fn test_concat() {
     );
 }
 
-#[test]
-fn test_json_array_access() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_json_array_access() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -162,6 +165,7 @@ fn test_json_array_access() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -173,7 +177,7 @@ fn test_json_array_access() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("json_array_access", &input).unwrap();
+    let output = runtime.call("json_array_access", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -185,9 +189,9 @@ fn test_json_array_access() {
     );
 }
 
-#[test]
-fn test_json_stringify() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_json_stringify() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -200,13 +204,14 @@ fn test_json_stringify() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![json_field("json")]);
     let arg0 = StringArray::from(vec![r#"[1, null, ""]"#]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("json_stringify", &input).unwrap();
+    let output = runtime.call("json_stringify", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -218,9 +223,9 @@ fn test_json_stringify() {
     );
 }
 
-#[test]
-fn test_binary_json_stringify() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_binary_json_stringify() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -234,13 +239,14 @@ fn test_binary_json_stringify() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![binary_json_field("json")]);
     let arg0 = BinaryArray::from(vec![(r#"[1, null, ""]"#).as_bytes()]);
     let input = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("add_element", &input).unwrap();
+    let output = runtime.call("add_element", &input).await.unwrap();
     let row = output
         .column(0)
         .as_any()
@@ -250,9 +256,9 @@ fn test_binary_json_stringify() {
     assert_eq!(std::str::from_utf8(row).unwrap(), r#"[1,null,"",10]"#);
 }
 
-#[test]
-fn test_large_binary_json_stringify() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_large_binary_json_stringify() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -266,13 +272,14 @@ fn test_large_binary_json_stringify() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![large_binary_json_field("json")]);
     let arg0 = LargeBinaryArray::from(vec![(r#"[1, null, ""]"#).as_bytes()]);
     let input = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("add_element", &input).unwrap();
+    let output = runtime.call("add_element", &input).await.unwrap();
     let row = output
         .column(0)
         .as_any()
@@ -282,9 +289,9 @@ fn test_large_binary_json_stringify() {
     assert_eq!(std::str::from_utf8(row).unwrap(), r#"[1,null,"",10]"#);
 }
 
-#[test]
-fn test_large_string_as_string() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_large_string_as_string() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -297,13 +304,14 @@ fn test_large_string_as_string() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("s", DataType::LargeUtf8, true)]);
     let arg0 = LargeStringArray::from(vec![r#"hello"#]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("string_length", &input).unwrap();
+    let output = runtime.call("string_length", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -315,9 +323,9 @@ fn test_large_string_as_string() {
     );
 }
 
-#[test]
-fn test_decimal128() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_decimal128() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -330,6 +338,7 @@ fn test_decimal128() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -345,7 +354,7 @@ fn test_decimal128() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("decimal128_add", &input).unwrap();
+    let output = runtime.call("decimal128_add", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -358,9 +367,9 @@ fn test_decimal128() {
     );
 }
 
-#[test]
-fn test_decimal256() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_decimal256() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -373,6 +382,7 @@ fn test_decimal256() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -388,7 +398,7 @@ fn test_decimal256() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("decimal256_add", &input).unwrap();
+    let output = runtime.call("decimal256_add", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -401,9 +411,9 @@ fn test_decimal256() {
     );
 }
 
-#[test]
-fn test_decimal_add() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_decimal_add() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -416,6 +426,7 @@ fn test_decimal_add() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![decimal_field("a"), decimal_field("b")]);
@@ -424,7 +435,7 @@ fn test_decimal_add() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let output = runtime.call("decimal_add", &input).unwrap();
+    let output = runtime.call("decimal_add", &input).await.unwrap();
     assert_eq!(output.schema().field(0), &decimal_field("add"));
     check(
         &[output],
@@ -437,9 +448,9 @@ fn test_decimal_add() {
     );
 }
 
-#[test]
-fn test_timestamp_second_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_timestamp_second_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -452,6 +463,7 @@ fn test_timestamp_second_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new(
@@ -462,7 +474,7 @@ fn test_timestamp_second_array() {
     let arg0 = TimestampSecondArray::from(vec![Some(1), None, Some(3)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("timestamp_array", &input).unwrap();
+    let output = runtime.call("timestamp_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -476,9 +488,9 @@ fn test_timestamp_second_array() {
     );
 }
 
-#[test]
-fn test_timestamp_millisecond_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_timestamp_millisecond_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -491,6 +503,7 @@ fn test_timestamp_millisecond_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new(
@@ -501,7 +514,7 @@ fn test_timestamp_millisecond_array() {
     let arg0 = TimestampMillisecondArray::from(vec![Some(1000), None, Some(3000)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("timestamp_array", &input).unwrap();
+    let output = runtime.call("timestamp_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -515,9 +528,9 @@ fn test_timestamp_millisecond_array() {
     );
 }
 
-#[test]
-fn test_timestamp_microsecond_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_timestamp_microsecond_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -530,6 +543,7 @@ fn test_timestamp_microsecond_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new(
@@ -540,7 +554,7 @@ fn test_timestamp_microsecond_array() {
     let arg0 = TimestampMicrosecondArray::from(vec![Some(1000000), None, Some(3000000)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("timestamp_array", &input).unwrap();
+    let output = runtime.call("timestamp_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -554,9 +568,9 @@ fn test_timestamp_microsecond_array() {
     );
 }
 
-#[test]
-fn test_timestamp_nanosecond_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_timestamp_nanosecond_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -569,6 +583,7 @@ fn test_timestamp_nanosecond_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new(
@@ -579,7 +594,7 @@ fn test_timestamp_nanosecond_array() {
     let arg0 = TimestampNanosecondArray::from(vec![Some(1000000), None, Some(3000000)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("timestamp_array", &input).unwrap();
+    let output = runtime.call("timestamp_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -593,9 +608,9 @@ fn test_timestamp_nanosecond_array() {
     );
 }
 
-#[test]
-fn test_date32_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_date32_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -608,13 +623,14 @@ fn test_date32_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Date32, true)]);
     let arg0 = Date32Array::from(vec![Some(1), None, Some(3)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("date_array", &input).unwrap();
+    let output = runtime.call("date_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -628,9 +644,9 @@ fn test_date32_array() {
     );
 }
 
-#[test]
-fn test_typed_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_typed_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -643,6 +659,7 @@ fn test_typed_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     /// Generate a record batch with a single column of type `List<T>`.
@@ -672,7 +689,7 @@ fn test_typed_array() {
     ];
 
     for (input, expected) in cases.iter() {
-        let output = runtime.call("object_type", input).unwrap();
+        let output = runtime.call("object_type", input).await.unwrap();
         let object_type = output
             .column(0)
             .as_any()
@@ -683,9 +700,9 @@ fn test_typed_array() {
     }
 }
 
-#[test]
-fn test_return_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_return_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -701,13 +718,14 @@ fn test_return_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
     let arg0 = Int32Array::from(vec![Some(1), None, Some(3)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("to_array", &input).unwrap();
+    let output = runtime.call("to_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -721,9 +739,9 @@ fn test_return_array() {
     );
 }
 
-#[test]
-fn test_return_large_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_return_large_array() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -739,13 +757,14 @@ fn test_return_large_array() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
     let arg0 = Int32Array::from(vec![Some(1), None, Some(3)]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("to_large_array", &input).unwrap();
+    let output = runtime.call("to_large_array", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -759,9 +778,9 @@ fn test_return_large_array() {
     );
 }
 
-#[test]
-fn test_key_value() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_key_value() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -781,13 +800,14 @@ fn test_key_value() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Utf8, true)]);
     let arg0 = StringArray::from(vec!["a=b"]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("key_value", &input).unwrap();
+    let output = runtime.call("key_value", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -799,9 +819,9 @@ fn test_key_value() {
     );
 }
 
-#[test]
-fn test_struct_to_json() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_struct_to_json() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -814,6 +834,7 @@ fn test_struct_to_json() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new(
@@ -839,7 +860,7 @@ fn test_struct_to_json() {
     ]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("to_json", &input).unwrap();
+    let output = runtime.call("to_json", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -852,9 +873,9 @@ fn test_struct_to_json() {
     );
 }
 
-#[test]
-fn test_range() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_range() {
+    let mut runtime = Runtime::new().await.unwrap();
 
     runtime
         .add_function(
@@ -869,6 +890,7 @@ fn test_range() {
             }
             "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
@@ -881,11 +903,11 @@ fn test_range() {
     assert_eq!(outputs.schema().field(1).name(), "range");
     assert_eq!(outputs.schema().field(1).data_type(), &DataType::Int32);
 
-    let o1 = outputs.next().unwrap().unwrap();
-    let o2 = outputs.next().unwrap().unwrap();
+    let o1 = outputs.next().await.unwrap().unwrap();
+    let o2 = outputs.next().await.unwrap().unwrap();
     assert_eq!(o1.num_rows(), 2);
     assert_eq!(o2.num_rows(), 2);
-    assert!(outputs.next().is_none());
+    assert!(outputs.next().await.unwrap().is_none());
 
     check(
         &[o1, o2],
@@ -901,9 +923,9 @@ fn test_range() {
     );
 }
 
-#[test]
-fn test_weighted_avg() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_weighted_avg() {
+    let mut runtime = Runtime::new().await.unwrap();
     runtime
         .add_aggregate(
             "weighted_avg",
@@ -940,6 +962,7 @@ fn test_weighted_avg() {
             }
 "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![
@@ -951,7 +974,7 @@ fn test_weighted_avg() {
     let input =
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0), Arc::new(arg1)]).unwrap();
 
-    let state = runtime.create_state("weighted_avg").unwrap();
+    let state = runtime.create_state("weighted_avg").await.unwrap();
     check_array(
         std::slice::from_ref(&state),
         expect![[r#"
@@ -962,7 +985,10 @@ fn test_weighted_avg() {
             +---------------------+"#]],
     );
 
-    let state = runtime.accumulate("weighted_avg", &state, &input).unwrap();
+    let state = runtime
+        .accumulate("weighted_avg", &state, &input)
+        .await
+        .unwrap();
     check_array(
         std::slice::from_ref(&state),
         expect![[r#"
@@ -974,7 +1000,7 @@ fn test_weighted_avg() {
     );
 
     let states = arrow_select::concat::concat(&[&state, &state]).unwrap();
-    let state = runtime.merge("weighted_avg", &states).unwrap();
+    let state = runtime.merge("weighted_avg", &states).await.unwrap();
     check_array(
         std::slice::from_ref(&state),
         expect![[r#"
@@ -985,7 +1011,7 @@ fn test_weighted_avg() {
             +-----------------------+"#]],
     );
 
-    let output = runtime.finish("weighted_avg", &state).unwrap();
+    let output = runtime.finish("weighted_avg", &state).await.unwrap();
     check_array(
         &[output],
         expect![[r#"
@@ -997,10 +1023,10 @@ fn test_weighted_avg() {
     );
 }
 
-#[test]
-fn test_timeout() {
-    let mut runtime = Runtime::new().unwrap();
-    runtime.set_timeout(Some(Duration::from_millis(1)));
+#[tokio::test]
+async fn test_timeout() {
+    let mut runtime = Runtime::new().await.unwrap();
+    runtime.set_timeout(Some(Duration::from_millis(1))).await;
 
     let js_code = r#"
         export function square(x) {
@@ -1018,13 +1044,14 @@ fn test_timeout() {
             CallMode::ReturnNullOnNullInput,
             js_code,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
     let arg0 = Int32Array::from(vec![100]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("square", &input).unwrap();
+    let output = runtime.call("square", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -1039,14 +1066,14 @@ fn test_timeout() {
     let arg0 = Int32Array::from(vec![i32::MAX]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let err = runtime.call("square", &input).unwrap_err();
+    let err = runtime.call("square", &input).await.unwrap_err();
     assert!(format!("{err:?}").contains("interrupted"))
 }
 
-#[test]
-fn test_memory_limit() {
-    let mut runtime = Runtime::new().unwrap();
-    runtime.set_memory_limit(Some(1 << 20)); // 1MB
+#[tokio::test]
+async fn test_memory_limit() {
+    let mut runtime = Runtime::new().await.unwrap();
+    runtime.set_memory_limit(Some(1 << 20)).await; // 1MB
 
     let js_code = r#"
         export function alloc(x) {
@@ -1061,13 +1088,14 @@ fn test_memory_limit() {
             CallMode::ReturnNullOnNullInput,
             js_code,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
     let arg0 = Int32Array::from(vec![100]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("alloc", &input).unwrap();
+    let output = runtime.call("alloc", &input).await.unwrap();
     check(
         &[output],
         expect![[r#"
@@ -1082,13 +1110,13 @@ fn test_memory_limit() {
     let arg0 = Int32Array::from(vec![1 << 20]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let err = runtime.call("alloc", &input).unwrap_err();
+    let err = runtime.call("alloc", &input).await.unwrap_err();
     assert!(format!("{err:?}").contains("out of memory"))
 }
 
-#[test]
-fn test_view_array() {
-    let mut runtime = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_view_array() {
+    let mut runtime = Runtime::new().await.unwrap();
     runtime
         .add_function(
             "echo",
@@ -1100,13 +1128,14 @@ export function echo(x) {
 }
 "#,
         )
+        .await
         .unwrap();
 
     let schema = Schema::new(vec![Field::new("x", DataType::Utf8View, true)]);
     let arg0 = StringViewArray::from(vec!["hello", "world"]);
     let input = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arg0)]).unwrap();
 
-    let output = runtime.call("echo", &input).unwrap();
+    let output = runtime.call("echo", &input).await.unwrap();
 
     check(
         &[output],
@@ -1121,8 +1150,8 @@ export function echo(x) {
 }
 
 /// assert Runtime is Send and Sync
-#[test]
-fn test_send_sync() {
+#[tokio::test]
+async fn test_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Runtime>();
 }


### PR DESCRIPTION
See background at #95

- As a result of switching to `rquickjs::AsyncRuntime`, all functions become `async` now.
- A new parameter `is_async: bool` is added into `add_function()` and `add_aggregate()` to distinguish async JS functions and normal ones.
- Added 2 test cases `test_async_rust_fn` and `test_async_echo` to show the usage.


## Benchmark

The performance loss is neglectable.

eric/async_js (4264b225989)

```
gcd/js                  time:   [97.258 µs 99.587 µs 102.82 µs]
range/js                time:   [3.8619 ms 3.8910 ms 3.9419 ms]
decimal/js              time:   [424.89 µs 429.35 µs 435.53 µs]
sum/js                  time:   [64.918 µs 66.507 µs 68.625 µs]
```

main (b0f755f463e)
 
```
gcd/js                  time:   [96.832 µs 99.487 µs 102.99 µs]
range/js                time:   [3.8789 ms 3.9929 ms 4.1527 ms]
decimal/js              time:   [422.98 µs 435.11 µs 450.86 µs]
sum/js                  time:   [61.390 µs 61.493 µs 61.619 µs]
```