### PR TITLE
chore: update changelog for async js udf support

### DIFF
--- a/arrow-udf-js/CHANGELOG.md
+++ b/arrow-udf-js/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add async function support, as a result:
+  - All methods of `Runtime` becomes `async`. Return value of `call_table_function` becomes an async `Stream`.
+  - A new `is_async` parameter is added to `add_function` and `add_aggregate` to specify the type of function.
+
 ## [0.5.0] - 2024-10-10
 
 ### Changed


### PR DESCRIPTION
Add release note for https://github.com/arrow-udf/arrow-udf/pull/97.

Maybe we haven't been ready to release a new version, let's first put the changlog under `[unreleased]`.