### PR TITLE
feat: JS batched function

### DIFF
--- a/arrow-udf-bench/benches/bench.rs
+++ b/arrow-udf-bench/benches/bench.rs
@@ -18,7 +18,7 @@ use arrow_arith::arity::binary;
 use arrow_array::{Int32Array, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use arrow_udf::function;
-use arrow_udf_js::Runtime as JsRuntime;
+use arrow_udf_js::{AggregateOptions, FunctionOptions, Runtime as JsRuntime};
 use arrow_udf_python::Runtime as PythonRuntime;
 use arrow_udf_wasm::Runtime as WasmRuntime;
 use criterion::async_executor::{AsyncExecutor as _, FuturesExecutor};
@@ -100,9 +100,8 @@ def gcd(a: int, b: int) -> int:
             rt.add_function(
                 "gcd",
                 DataType::Int32,
-                arrow_udf_js::CallMode::ReturnNullOnNullInput,
                 js_code,
-                false,
+                FunctionOptions::default().return_null_on_null_input(),
             )
             .await
             .unwrap();
@@ -184,9 +183,8 @@ def range1(n: int):
             rt.add_function(
                 "range",
                 DataType::Int32,
-                arrow_udf_js::CallMode::ReturnNullOnNullInput,
                 js_code,
-                false,
+                FunctionOptions::default().return_null_on_null_input(),
             )
             .await
             .unwrap();
@@ -255,9 +253,8 @@ def decimal_(a):
             rt.add_function(
                 "decimal",
                 decimal_field("decimal"),
-                arrow_udf_js::CallMode::ReturnNullOnNullInput,
                 js_code,
-                false,
+                FunctionOptions::default().return_null_on_null_input(),
             )
             .await
             .unwrap();
@@ -302,7 +299,6 @@ fn bench_eval_sum(c: &mut Criterion) {
                 "sum",
                 DataType::Int32,
                 DataType::Int32,
-                arrow_udf_js::CallMode::ReturnNullOnNullInput,
                 r#"
                     export function create_state() {
                         return 0;
@@ -313,8 +309,8 @@ fn bench_eval_sum(c: &mut Criterion) {
                     export function retract(state, value) {
                         return state - value;
                     }
-"#,
-                false,
+                "#,
+                AggregateOptions::default().return_null_on_null_input(),
             )
             .await
             .unwrap();

--- a/arrow-udf-js/README.md
+++ b/arrow-udf-js/README.md
@@ -23,7 +23,6 @@ runtime
     .add_function(
         "gcd",
         arrow_schema::DataType::Int32,
-        CallMode::ReturnNullOnNullInput,
         r#"
         export function gcd(a, b) {
             while (b != 0) {
@@ -34,8 +33,7 @@ runtime
             return a;
         }
         "#,
-        false,
-        false,
+        FunctionOptions::default().return_null_on_null_input(),
     )
     .await?;
 ```
@@ -174,7 +172,6 @@ runtime
     .add_function(
         "echo",
         DataType::Utf8View,
-        CallMode::ReturnNullOnNullInput,
         r#"
 export async function my_fetch_udf(id) {
     const response = await fetch("https://api.example.com/" + id);
@@ -182,8 +179,7 @@ export async function my_fetch_udf(id) {
     return data.value;
 }
 "#,
-        true, // set is_async to true
-        false,
+        FunctionOptions::default().return_null_on_null_input().async_mode(),
     )
     .await
     .unwrap();

--- a/arrow-udf-js/README.md
+++ b/arrow-udf-js/README.md
@@ -35,6 +35,7 @@ runtime
         }
         "#,
         false,
+        false,
     )
     .await?;
 ```
@@ -76,6 +77,7 @@ runtime
             }
         }
         "#,
+        false,
         false,
     )
     .await?;

--- a/arrow-udf-js/README.md
+++ b/arrow-udf-js/README.md
@@ -16,7 +16,7 @@ Create a `Runtime` and define your JS functions in string form.
 Note that the function must be exported and its name must match the one you pass to `add_function`.
 
 ```rust,ignore
-use arrow_udf_js::{Runtime, CallMode};
+use arrow_udf_js::{FunctionOptions, Runtime};
 
 let mut runtime = Runtime::new().await?;
 runtime
@@ -60,14 +60,13 @@ If you print the input and output batch, it will be like this:
 For set-returning functions (or so-called table functions), define the function as a generator:
 
 ```rust,ignore
-use arrow_udf_js::{Runtime, CallMode};
+use arrow_udf_js::{FunctionOptions, Runtime};
 
 let mut runtime = Runtime::new().await?;
 runtime
     .add_function(
         "range",
         arrow_schema::DataType::Int32,
-        CallMode::ReturnNullOnNullInput,
         r#"
         export function* range(n) {
             for (let i = 0; i < n; i++) {
@@ -75,8 +74,7 @@ runtime
             }
         }
         "#,
-        false,
-        false,
+        FunctionOptions::default().return_null_on_null_input(),
     )
     .await?;
 ```
@@ -197,14 +195,12 @@ runtime
     .add_function(
         "echo",
         DataType::Utf8View,
-        CallMode::ReturnNullOnNullInput,
         r#"
 export function echo(vals) {
     return vals.map(v => v + "!")
 }
 "#,
-        false,
-        true, // set is_batched to true
+        FunctionOptions::default().return_null_on_null_input().batched(),
     )
     .await
     .unwrap();

--- a/arrow-udf-js/README.md
+++ b/arrow-udf-js/README.md
@@ -163,7 +163,7 @@ We provide a [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_
 runtime.enable_fetch();
 ```
 
-To enable async functions, you need to set the `is_async` flag to `true` when adding the function. Then you can use the async `fetch()` function in your JavaScript code.
+To enable async functions, you need to set `async_mode()` when adding the function. Then you can use the async `fetch()` function in your JavaScript code.
 
 ```rust,ignore
 runtime

--- a/arrow-udf-js/examples/js.rs
+++ b/arrow-udf-js/examples/js.rs
@@ -38,6 +38,7 @@ async fn main() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -54,6 +55,7 @@ async fn main() {
                 return fib(x - 1) + fib(x - 2);
             }
             "#,
+            false,
             false,
         )
         .await

--- a/arrow-udf-js/examples/js.rs
+++ b/arrow-udf-js/examples/js.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
-use arrow_udf_js::{CallMode, Runtime};
+use arrow_udf_js::{FunctionOptions, Runtime};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -26,7 +26,6 @@ async fn main() {
         .add_function(
             "gcd",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function gcd(a, b) {
                 while (b != 0) {
@@ -37,8 +36,7 @@ async fn main() {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -47,7 +45,6 @@ async fn main() {
         .add_function(
             "fib",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function fib(x) {
                 if (x <= 1) 
@@ -55,8 +52,7 @@ async fn main() {
                 return fib(x - 1) + fib(x - 2);
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();

--- a/arrow-udf-js/src/doc_create_aggregate.txt
+++ b/arrow-udf-js/src/doc_create_aggregate.txt
@@ -1,6 +1,6 @@
 # // this piece of code is included in the documentation
 #
-# use arrow_udf_js::{Runtime, CallMode};
+# use arrow_udf_js::{AggregateOptions, Runtime};
 # use arrow_schema::{DataType, Field, Schema};
 # use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch};
 # use std::sync::Arc;
@@ -10,7 +10,6 @@
 #     "sum",
 #     DataType::Int32,
 #     DataType::Int32,
-#     CallMode::ReturnNullOnNullInput,
 #     r#"
 #     export function create_state() {
 #         return 0;
@@ -24,8 +23,8 @@
 #     export function merge(state1, state2) {
 #         return state1 + state2;
 #     }
-# "#,
-#     false,
+#     "#,
+#     AggregateOptions::default().return_null_on_null_input(),
 # )
 # .await
 # .unwrap();

--- a/arrow-udf-js/src/doc_create_function.txt
+++ b/arrow-udf-js/src/doc_create_function.txt
@@ -1,5 +1,5 @@
 # // this piece of code is included in the documentation
-# use arrow_udf_js::{Runtime, CallMode};
+# use arrow_udf_js::{FunctionOptions, Runtime};
 # use arrow_schema::{DataType, Field, Schema};
 # use arrow_array::{RecordBatch, Int32Array};
 # use std::sync::Arc;
@@ -8,7 +8,6 @@
 #     .add_function(
 #         "gcd",
 #         DataType::Int32,
-#         CallMode::ReturnNullOnNullInput,
 #         r#"
 #         export function gcd(a, b) {
 #             while (b != 0) {
@@ -18,9 +17,8 @@
 #             }
 #             return a;
 #         }
-# "#,
-#         false,
-#         false,
+#         "#,
+#         FunctionOptions::default().return_null_on_null_input(),
 #     )
 #     .await
 #     .unwrap();
@@ -28,16 +26,14 @@
 #     .add_function(
 #         "series",
 #         DataType::Int32,
-#         CallMode::ReturnNullOnNullInput,
 #         r#"
 #         export function* series(n) {
 #             for (let i = 0; i < n; i++) {
 #                 yield i;
 #             }
 #         }
-# "#,
-#         false,
-#         false,
+#         "#,
+#         FunctionOptions::default().return_null_on_null_input(),
 #     )
 #     .await
 #     .unwrap();

--- a/arrow-udf-js/src/doc_create_function.txt
+++ b/arrow-udf-js/src/doc_create_function.txt
@@ -20,6 +20,7 @@
 #         }
 # "#,
 #         false,
+#         false,
 #     )
 #     .await
 #     .unwrap();
@@ -35,6 +36,7 @@
 #             }
 #         }
 # "#,
+#         false,
 #         false,
 #     )
 #     .await

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -580,7 +580,7 @@ impl Runtime {
                 let mut args = Args::new(ctx.clone(), filtered_columns.len());
                 for js_values in filtered_columns {
                     let js_array = js_values.into_iter().collect_js::<JsArray>(&ctx)?;
-                    args.push_args(js_array)?;
+                    args.push_arg(js_array)?;
                 }
                 let filtered_result: Vec<_> = self
                     .call_user_fn(&ctx, &js_function, args, function.is_async)
@@ -592,12 +592,13 @@ impl Runtime {
                 let mut result = Vec::with_capacity(n_rows);
                 for b in bitmap.iter() {
                     if *b {
-                        result.push(Value::new_null(ctx.clone()));
-                    } else {
                         let v = iter.next().expect("filtered result length mismatch");
                         result.push(v);
+                    } else {
+                        result.push(Value::new_null(ctx.clone()));
                     }
                 }
+                assert!(iter.next().is_none(), "filtered result length mismatch");
                 result
             }
         };

--- a/arrow-udf-js/src/lib.rs
+++ b/arrow-udf-js/src/lib.rs
@@ -560,8 +560,8 @@ impl Runtime {
                 // 1. Build a bitmap of which rows have nulls
                 let mut bitmap = Vec::with_capacity(n_rows);
                 for i in 0..n_rows {
-                    let contains_null = (0..n_cols).any(|j| js_columns[j][i].is_null());
-                    bitmap.push(!contains_null);
+                    let has_null = (0..n_cols).any(|j| js_columns[j][i].is_null());
+                    bitmap.push(!has_null);
                 }
 
                 // 2. Build new inputs with only the rows that don't have nulls

--- a/arrow-udf-js/tests/fetch.rs
+++ b/arrow-udf-js/tests/fetch.rs
@@ -115,6 +115,7 @@ async fn test_fetch_in_udf() {
             CallMode::CalledOnNullInput,
             &js_code,
             true,
+            false,
         )
         .await
         .unwrap();
@@ -354,7 +355,8 @@ async fn test_fetch_in_udtf() {
             DataType::Utf8,
             CallMode::ReturnNullOnNullInput,
             &js_code,
-            true, // is_async
+            true,
+            false,
         )
         .await
         .unwrap();

--- a/arrow-udf-js/tests/fetch.rs
+++ b/arrow-udf-js/tests/fetch.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use arrow_array::{ArrayRef, Int32Array, RecordBatch};
 use arrow_cast::pretty::{pretty_format_batches, pretty_format_columns};
 use arrow_schema::{DataType, Field, Schema};
-use arrow_udf_js::{CallMode, Runtime};
+use arrow_udf_js::{AggregateOptions, FunctionOptions, Runtime};
 use expect_test::{expect, Expect};
 use mockito::Server;
 use rquickjs::{async_with, AsyncContext};
@@ -112,10 +112,8 @@ async fn test_fetch_in_udf() {
         .add_function(
             "test_fetch",
             DataType::Utf8,
-            CallMode::CalledOnNullInput,
             &js_code,
-            true,
-            false,
+            FunctionOptions::default().async_mode(),
         )
         .await
         .unwrap();
@@ -237,9 +235,10 @@ async fn test_fetch_in_udaf() {
             "fetch_agg",
             DataType::Int32, // state type
             DataType::Int32, // output type
-            CallMode::ReturnNullOnNullInput,
             &js_code,
-            true, // is_async
+            AggregateOptions::default()
+                .return_null_on_null_input()
+                .async_mode(),
         )
         .await
         .unwrap();
@@ -353,10 +352,10 @@ async fn test_fetch_in_udtf() {
         .add_function(
             "fetch_items",
             DataType::Utf8,
-            CallMode::ReturnNullOnNullInput,
             &js_code,
-            true,
-            false,
+            FunctionOptions::default()
+                .return_null_on_null_input()
+                .async_mode(),
         )
         .await
         .unwrap();

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -1434,12 +1434,12 @@ async fn test_batched_return_null_on_null_input() {
             DataType::Utf8View,
             CallMode::ReturnNullOnNullInput,
             r#"
-export function echo(x) {
-    return x + "!"
+export function echo(vals) {
+    return vals.map(v => v + "!")
 }
 "#,
             false,
-            false,
+            true,
         )
         .await
         .unwrap();

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -1473,7 +1473,7 @@ async fn test_batched_called_on_null_input() {
             CallMode::CalledOnNullInput,
             r#"
 export function echo(vals) {
-    return vals.map(v => String(v) + "!")
+    return vals.map(v => v + "!")
 }
 "#,
             false,

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -25,7 +25,7 @@ use arrow_array::{
 use arrow_buffer::i256;
 use arrow_cast::pretty::{pretty_format_batches, pretty_format_columns};
 use arrow_schema::{DataType, Field, Fields, Schema};
-use arrow_udf_js::{CallMode, Runtime};
+use arrow_udf_js::{AggregateOptions, FunctionOptions, Runtime};
 use expect_test::{expect, Expect};
 use rquickjs::prelude::Async;
 use rquickjs::{async_with, Function};
@@ -48,10 +48,8 @@ async fn test_gcd() {
         .add_function(
             "gcd",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             js_code,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -94,10 +92,8 @@ async fn test_to_string() {
         .add_function(
             "to_string",
             DataType::Utf8,
-            CallMode::CalledOnNullInput,
             js_code,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -127,14 +123,12 @@ async fn test_concat() {
         .add_function(
             "concat",
             DataType::Binary,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function concat(a, b) {
                 return a.concat(b);
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -168,14 +162,12 @@ async fn test_json_array_access() {
         .add_function(
             "json_array_access",
             json_field("json"),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function json_array_access(array, i) {
                 return array[i];
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -209,14 +201,12 @@ async fn test_json_stringify() {
         .add_function(
             "json_stringify",
             DataType::Utf8,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function json_stringify(object) {
                 return JSON.stringify(object);
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -245,15 +235,13 @@ async fn test_binary_json_stringify() {
         .add_function(
             "add_element",
             binary_json_field("object"),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function add_element(object) {
                 object.push(10);
                 return object;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -280,15 +268,13 @@ async fn test_large_binary_json_stringify() {
         .add_function(
             "add_element",
             large_binary_json_field("object"),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function add_element(object) {
                 object.push(10);
                 return object;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -315,14 +301,12 @@ async fn test_large_string_as_string() {
         .add_function(
             "string_length",
             DataType::LargeUtf8,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function string_length(s) {
                 return "string length is " + s.length;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -351,14 +335,12 @@ async fn test_decimal128() {
         .add_function(
             "decimal128_add",
             DataType::Decimal128(19, 2),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function decimal128_add(a, b) {
                 return a + b + BigDecimal('0.000001');
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -397,14 +379,12 @@ async fn test_decimal256() {
         .add_function(
             "decimal256_add",
             DataType::Decimal256(19, 2),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function decimal256_add(a, b) {
                 return a + b + BigDecimal('0.000001');
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -443,14 +423,12 @@ async fn test_decimal_add() {
         .add_function(
             "decimal_add",
             decimal_field("add"),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function decimal_add(a, b) {
                 return a + b;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -482,14 +460,12 @@ async fn test_timestamp_second_array() {
         .add_function(
             "timestamp_array",
             DataType::Timestamp(arrow_schema::TimeUnit::Second, None),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function timestamp_array(a) {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -524,14 +500,12 @@ async fn test_timestamp_millisecond_array() {
         .add_function(
             "timestamp_array",
             DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function timestamp_array(a) {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -566,14 +540,12 @@ async fn test_timestamp_microsecond_array() {
         .add_function(
             "timestamp_array",
             DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function timestamp_array(a) {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -608,14 +580,12 @@ async fn test_timestamp_nanosecond_array() {
         .add_function(
             "timestamp_array",
             DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function timestamp_array(a) {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -650,14 +620,12 @@ async fn test_date32_array() {
         .add_function(
             "date_array",
             DataType::Date32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function date_array(a) {
                 return a;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -688,14 +656,12 @@ async fn test_typed_array() {
         .add_function(
             "object_type",
             DataType::Utf8,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function object_type(a) {
                 return Object.prototype.toString.call(a);
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -746,7 +712,6 @@ async fn test_arg_array() {
         .add_function(
             "from_array",
             DataType::Int32,
-            CallMode::CalledOnNullInput,
             r#"
             export function from_array(x) {
                 if(x == null) {
@@ -758,8 +723,7 @@ async fn test_arg_array() {
                 return null;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -800,7 +764,6 @@ async fn test_return_array() {
         .add_function(
             "to_array",
             DataType::new_list(DataType::Int32, true),
-            CallMode::CalledOnNullInput,
             r#"
             export function to_array(x) {
                 if(x == null) {
@@ -809,8 +772,7 @@ async fn test_return_array() {
                 return [x];
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -841,7 +803,6 @@ async fn test_arg_large_array() {
         .add_function(
             "from_large_array",
             DataType::Int32,
-            CallMode::CalledOnNullInput,
             r#"
             export function from_large_array(x) {
                 if(x == null) {
@@ -853,8 +814,7 @@ async fn test_arg_large_array() {
                 return null;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -895,7 +855,6 @@ async fn test_return_large_array() {
         .add_function(
             "to_large_array",
             DataType::new_large_list(DataType::Int32, true),
-            CallMode::CalledOnNullInput,
             r#"
             export function to_large_array(x) {
                 if(x == null) {
@@ -904,8 +863,7 @@ async fn test_return_large_array() {
                 return [x, x+1, x+2];
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -936,7 +894,6 @@ async fn test_arg_map() {
         .add_function(
             "from_map",
             DataType::Utf8,
-            CallMode::CalledOnNullInput,
             r#"
             export function from_map(x) {
                 if(x == null) {
@@ -948,8 +905,7 @@ async fn test_arg_map() {
                 return null;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -1003,7 +959,6 @@ async fn test_return_map() {
                 )),
                 false,
             ),
-            CallMode::CalledOnNullInput,
             r#"
             export function to_map(x, y) {
                 if(x == null || y == null) {
@@ -1012,8 +967,7 @@ async fn test_return_map() {
                 return {k1:x,k2:y};
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default(),
         )
         .await
         .unwrap();
@@ -1055,15 +1009,13 @@ async fn test_key_value() {
                 ]
                 .into(),
             ),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function key_value(s) {
                 const [key, value] = s.split("=", 2);
                 return {key, value};
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1092,14 +1044,12 @@ async fn test_struct_to_json() {
         .add_function(
             "to_json",
             json_field("to_json"),
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function to_json(object) {
                 return object;
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1148,7 +1098,6 @@ async fn test_range() {
         .add_function(
             "range",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function* range(n) {
                 for (let i = 0; i < n; i++) {
@@ -1156,8 +1105,7 @@ async fn test_range() {
                 }
             }
             "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1206,7 +1154,6 @@ async fn test_weighted_avg() {
                 .into(),
             ),
             DataType::Float32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export function create_state() {
                 return {sum: 0, weight: 0};
@@ -1230,7 +1177,7 @@ async fn test_weighted_avg() {
                 return state.sum / state.weight;
             }
 "#,
-            false,
+            AggregateOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1311,10 +1258,8 @@ async fn test_timeout() {
         .add_function(
             "square",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             js_code,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1357,10 +1302,8 @@ async fn test_memory_limit() {
         .add_function(
             "alloc",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             js_code,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1395,14 +1338,12 @@ async fn test_view_array() {
         .add_function(
             "echo",
             DataType::Utf8View,
-            CallMode::ReturnNullOnNullInput,
             r#"
 export function echo(x) {
     return x + "!"
 }
 "#,
-            false,
-            false,
+            FunctionOptions::default().return_null_on_null_input(),
         )
         .await
         .unwrap();
@@ -1432,14 +1373,14 @@ async fn test_batched_return_null_on_null_input() {
         .add_function(
             "echo",
             DataType::Utf8View,
-            CallMode::ReturnNullOnNullInput,
             r#"
 export function echo(vals) {
     return vals.map(v => v + "!")
 }
 "#,
-            false,
-            true,
+            FunctionOptions::default()
+                .return_null_on_null_input()
+                .batched(),
         )
         .await
         .unwrap();
@@ -1470,14 +1411,12 @@ async fn test_batched_called_on_null_input() {
         .add_function(
             "echo",
             DataType::Utf8View,
-            CallMode::CalledOnNullInput,
             r#"
 export function echo(vals) {
     return vals.map(v => v + "!")
 }
 "#,
-            false,
-            true,
+            FunctionOptions::default().batched(),
         )
         .await
         .unwrap();
@@ -1508,14 +1447,14 @@ async fn test_async_echo() {
         .add_function(
             "echo",
             DataType::Utf8View,
-            CallMode::ReturnNullOnNullInput,
             r#"
 export async function echo(x) {
     return x + "!"
 }
 "#,
-            true,
-            false,
+            FunctionOptions::default()
+                .return_null_on_null_input()
+                .async_mode(),
         )
         .await
         .unwrap();
@@ -1546,7 +1485,6 @@ async fn test_async_range() {
         .add_function(
             "range",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             r#"
             export async function* range(n) {
                 for (let i = 0; i < n; i++) {
@@ -1554,8 +1492,9 @@ async fn test_async_range() {
                 }
             }
             "#,
-            true,
-            false,
+            FunctionOptions::default()
+                .return_null_on_null_input()
+                .async_mode(),
         )
         .await
         .unwrap();
@@ -1617,14 +1556,14 @@ async fn test_async_rust_fn() {
         .add_function(
             "delayStrlen",
             DataType::Int32,
-            CallMode::ReturnNullOnNullInput,
             r#"
 export async function delayStrlen(s) {
     return await native_delay_strlen(s);
 }
 "#,
-            true,
-            false,
+            FunctionOptions::default()
+                .return_null_on_null_input()
+                .async_mode(),
         )
         .await
         .unwrap();

--- a/arrow-udf-js/tests/js.rs
+++ b/arrow-udf-js/tests/js.rs
@@ -51,6 +51,7 @@ async fn test_gcd() {
             CallMode::ReturnNullOnNullInput,
             js_code,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -96,6 +97,7 @@ async fn test_to_string() {
             CallMode::CalledOnNullInput,
             js_code,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -131,6 +133,7 @@ async fn test_concat() {
                 return a.concat(b);
             }
             "#,
+            false,
             false,
         )
         .await
@@ -172,6 +175,7 @@ async fn test_json_array_access() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -212,6 +216,7 @@ async fn test_json_stringify() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -248,6 +253,7 @@ async fn test_binary_json_stringify() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -282,6 +288,7 @@ async fn test_large_binary_json_stringify() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -314,6 +321,7 @@ async fn test_large_string_as_string() {
                 return "string length is " + s.length;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -349,6 +357,7 @@ async fn test_decimal128() {
                 return a + b + BigDecimal('0.000001');
             }
             "#,
+            false,
             false,
         )
         .await
@@ -395,6 +404,7 @@ async fn test_decimal256() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -440,6 +450,7 @@ async fn test_decimal_add() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -477,6 +488,7 @@ async fn test_timestamp_second_array() {
                 return a;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -519,6 +531,7 @@ async fn test_timestamp_millisecond_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -559,6 +572,7 @@ async fn test_timestamp_microsecond_array() {
                 return a;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -601,6 +615,7 @@ async fn test_timestamp_nanosecond_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -642,6 +657,7 @@ async fn test_date32_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -678,6 +694,7 @@ async fn test_typed_array() {
                 return Object.prototype.toString.call(a);
             }
             "#,
+            false,
             false,
         )
         .await
@@ -742,6 +759,7 @@ async fn test_arg_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -792,6 +810,7 @@ async fn test_return_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -834,6 +853,7 @@ async fn test_arg_large_array() {
                 return null;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -885,6 +905,7 @@ async fn test_return_large_array() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -927,6 +948,7 @@ async fn test_arg_map() {
                 return null;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -991,6 +1013,7 @@ async fn test_return_map() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -1040,6 +1063,7 @@ async fn test_key_value() {
             }
             "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -1074,6 +1098,7 @@ async fn test_struct_to_json() {
                 return object;
             }
             "#,
+            false,
             false,
         )
         .await
@@ -1131,6 +1156,7 @@ async fn test_range() {
                 }
             }
             "#,
+            false,
             false,
         )
         .await
@@ -1288,6 +1314,7 @@ async fn test_timeout() {
             CallMode::ReturnNullOnNullInput,
             js_code,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -1333,6 +1360,7 @@ async fn test_memory_limit() {
             CallMode::ReturnNullOnNullInput,
             js_code,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -1374,6 +1402,7 @@ export function echo(x) {
 }
 "#,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -1410,6 +1439,7 @@ export async function echo(x) {
 }
 "#,
             true,
+            false,
         )
         .await
         .unwrap();
@@ -1449,6 +1479,7 @@ async fn test_async_range() {
             }
             "#,
             true,
+            false,
         )
         .await
         .unwrap();
@@ -1517,6 +1548,7 @@ export async function delayStrlen(s) {
 }
 "#,
             true,
+            false,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Motivation: Many real-world APIs support batching, such as [text embedding](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input). With `is_batched = true`, users can call API once for multiple rows of inputs.

This is somehow related to https://github.com/arrow-udf/arrow-udf/pull/97#issuecomment-2614260401 but in a different approach. 