### PR TITLE
refactor: make `TableFunction` return `RecordBatchReader`

### DIFF
--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -433,12 +433,13 @@ impl FunctionAttr {
                     -> ::arrow_udf::Result<Box<dyn ::arrow_udf::codegen::arrow_array::RecordBatchReader>>
                 {
                     const BATCH_SIZE: usize = 1024;
-                    use ::arrow_udf::codegen::genawaiter2::{rc::gen, yield_};
-                    use ::arrow_udf::codegen::arrow_array::array::*;
-                    use ::arrow_udf::codegen::arrow_schema::{Schema, SchemaRef};
+                    use ::arrow_udf::codegen::genawaiter2::{self, rc::gen, yield_};
+                    use ::arrow_udf::codegen::arrow_array::{array::*, RecordBatchIterator};
+                    use ::arrow_udf::codegen::arrow_schema::{self, DataType, Field, Schema, SchemaRef};
+                    use ::arrow_udf::codegen::once_cell;
 
                     static SCHEMA: once_cell::sync::Lazy<SchemaRef> = once_cell::sync::Lazy::new(|| {
-                        Arc::new(Schema::new(vec![
+                        std::sync::Arc::new(Schema::new(vec![
                             Field::new("row", DataType::Int32, true),
                             #ret_data_type,
                             #error_field

--- a/arrow-udf/CHANGELOG.md
+++ b/arrow-udf/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `TableFunction` now returns a `RecordBatchReader`.
+
 ## [0.5.2] - 2024-12-24
 
 ### Fixed

--- a/arrow-udf/src/lib.rs
+++ b/arrow-udf/src/lib.rs
@@ -14,7 +14,7 @@
 
 #![doc = include_str!("../README.md")]
 
-use arrow_array::RecordBatch;
+use arrow_array::{RecordBatch, RecordBatchReader};
 pub use arrow_schema::ArrowError as Error;
 pub use arrow_udf_macros::function;
 
@@ -30,8 +30,7 @@ pub mod types;
 pub type ScalarFunction = fn(input: &RecordBatch) -> Result<RecordBatch>;
 
 /// A table function that operates on a record batch and returns an iterator of record batches.
-pub type TableFunction =
-    for<'a> fn(input: &'a RecordBatch) -> Result<Box<dyn Iterator<Item = RecordBatch> + 'a>>;
+pub type TableFunction = fn(input: &RecordBatch) -> Result<Box<dyn RecordBatchReader>>;
 
 /// Internal APIs used by macros.
 #[doc(hidden)]


### PR DESCRIPTION
Generated table functions now return `RecordBatchReader` in order to provide schema before consuming the iterator.
They also no longer borrow input record batch, making C wrapper simpler.

```rust
pub type TableFunction = fn(input: &RecordBatch) -> Result<Box<dyn RecordBatchReader>>;
```

Other public APIs are unaffected.