### PR TITLE
feat(flight): support batched python remote udf

### DIFF
--- a/arrow-udf-flight/python/CHANGELOG.md
+++ b/arrow-udf-flight/python/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.2] - todo
+## [0.3.0] - todo
+
+### Added
+
+- Add `batch` keyword parameter to the `udf` decorator. When it is set to `True`, the UDF will receive a batch of input instead of just one. Example:
+    ```py
+    @udf(input_types=["string"], result_type="float32[]", batch=True)
+    def text_embedding(texts: List[str]) -> List[List[float]]:
+        embeddings = [
+            e.embedding
+            for e in openai.embeddings.create(
+                model="text-embedding-ada-002",
+                input=texts,
+                encoding_format="float",
+            ).data
+        ]
+        return embeddings
+    ```
+
+## [0.2.2] - 2025-01-15
 
 ### Fixed
 

--- a/arrow-udf-flight/python/CHANGELOG.md
+++ b/arrow-udf-flight/python/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - todo
+## [0.3.0] - 2025-02-12
 
 ### Added
 

--- a/arrow-udf-flight/python/example.py
+++ b/arrow-udf-flight/python/example.py
@@ -230,6 +230,23 @@ def return_all(
     }
 
 
+@udf(input_types=["string"], result_type="float32[]", batch=True)
+def text_embedding(texts: List[str]) -> List[List[float]]:
+    # embeddings = [
+    #     e.embedding
+    #     for e in openai.embeddings.create(
+    #         model="text-embedding-ada-002",
+    #         input=texts,
+    #         encoding_format="float",
+    #     ).data
+    # ]
+    embeddings = [
+        [0.1, 0.2],
+        [0.3, 0.4],
+    ]
+    return embeddings
+
+
 if __name__ == "__main__":
     server = UdfServer(location="localhost:8815")
     server.add_function(int_42)
@@ -247,4 +264,5 @@ if __name__ == "__main__":
     server.add_function(json_concat)
     server.add_function(json_array_identity)
     server.add_function(return_all)
+    server.add_function(text_embedding)
     server.serve()

--- a/arrow-udf-flight/python/pyproject.toml
+++ b/arrow-udf-flight/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arrow-udf"
-version = "0.2.2"
+version = "0.3.0"
 authors = [{ name = "RisingWave Labs" }]
 description = "A user-defined function framework for Apache Arrow"
 readme = "README.md"


### PR DESCRIPTION
So that we can call external APIs with a batch of inputs instead of doing it row by row:

```py
@udf(input_types=["string"], result_type="float32[]", batch=True)
def text_embedding(texts: List[str]) -> List[List[float]]:
    embeddings = [
        e.embedding
        for e in openai.embeddings.create(
            model="text-embedding-ada-002",
            input=texts,
            encoding_format="float",
        ).data
    ]
    return embeddings
```