### PR TITLE
Fix global_registry

### DIFF
--- a/arrow-udf-bench/Cargo.toml
+++ b/arrow-udf-bench/Cargo.toml
@@ -8,9 +8,6 @@ keywords = ["arrow", "udf"]
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[lints.rust]
-unexpected_cfgs = { level = "allow" }
-
 [dev-dependencies]
 arrow-arith.workspace = true
 arrow-array.workspace = true

--- a/arrow-udf-example/.cargo/config.toml
+++ b/arrow-udf-example/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-wasip1"

--- a/arrow-udf-example/Cargo.toml
+++ b/arrow-udf-example/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[lints.rust]
-unexpected_cfgs = { level = "allow" }
-
 [dependencies]
-arrow-udf = { path = "../arrow-udf" }
+arrow-udf = { path = "../arrow-udf", features = ["global_registry"] }
+linkme = { version = "0.3" }

--- a/arrow-udf-example/Cargo.toml
+++ b/arrow-udf-example/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow-udf = { path = "../arrow-udf", features = ["global_registry"] }
-linkme = { version = "0.3" }
+arrow-udf = { path = "../arrow-udf" }

--- a/arrow-udf-macros/Cargo.toml
+++ b/arrow-udf-macros/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 [lib]
 proc-macro = true
 
+[features]
+global_registry = []
+
 [dependencies]
 base64 = "0.22"
 itertools = "0.12"

--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -79,6 +79,7 @@ impl FunctionAttr {
             };
             quote! {
                 #[::arrow_udf::codegen::linkme::distributed_slice(::arrow_udf::sig::SIGNATURES)]
+                #[linkme(crate = ::arrow_udf::codegen::linkme)]
                 fn #sig_name() -> ::arrow_udf::sig::FunctionSignature {
                     use ::arrow_udf::sig::{FunctionSignature, FunctionKind};
                     use ::arrow_udf::codegen::arrow_schema::{self, TimeUnit, IntervalUnit, Field};

--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -48,32 +48,53 @@ impl FunctionAttr {
     ///
     /// The types of arguments and return value should not contain wildcard.
     pub fn generate_function_descriptor(&self, user_fn: &UserFunctionAttr) -> Result<TokenStream2> {
-        let name = self.name.clone();
-        let variadic = matches!(self.args.last(), Some(t) if t == "...");
-        let args = match variadic {
-            true => &self.args[..self.args.len() - 1],
-            false => &self.args[..],
-        }
-        .iter()
-        .map(|ty| field("", ty))
-        .collect_vec();
-        let ret = field(&self.name, &self.ret);
-
         let eval_name = match &self.output {
             Some(output) => format_ident!("{}", output),
             None => format_ident!("{}_eval", self.ident_name()),
         };
-        let sig_name = format_ident!("{}_sig", self.ident_name());
         let ffi_name = format_ident!("{}_ffi", self.ident_name());
         let export_name = format!("arrowudf_{}", base64_encode(&self.normalize_signature()));
         let eval_function = self.generate_function(user_fn, &eval_name)?;
-        let kind = match self.is_table_function {
-            true => quote! { Table },
-            false => quote! { Scalar },
-        };
+
         let ffi_wrapper = match self.is_table_function {
             true => quote! { table_wrapper },
             false => quote! { scalar_wrapper },
+        };
+
+        let global_registry = if cfg!(feature = "global_registry") {
+            let name = self.name.clone();
+            let variadic = matches!(self.args.last(), Some(t) if t == "...");
+            let args = match variadic {
+                true => &self.args[..self.args.len() - 1],
+                false => &self.args[..],
+            }
+            .iter()
+            .map(|ty| field("", ty))
+            .collect_vec();
+            let ret = field(&self.name, &self.ret);
+            let sig_name = format_ident!("{}_sig", self.ident_name());
+            let kind = match self.is_table_function {
+                true => quote! { Table },
+                false => quote! { Scalar },
+            };
+            quote! {
+                #[::arrow_udf::codegen::linkme::distributed_slice(::arrow_udf::sig::SIGNATURES)]
+                fn #sig_name() -> ::arrow_udf::sig::FunctionSignature {
+                    use ::arrow_udf::sig::{FunctionSignature, FunctionKind};
+                    use ::arrow_udf::codegen::arrow_schema::{self, TimeUnit, IntervalUnit, Field};
+
+                    let args: Vec<Field> = vec![#(#args),*];
+                    FunctionSignature {
+                        name: #name.into(),
+                        arg_types: args.into(),
+                        variadic: #variadic,
+                        return_type: #ret,
+                        function: FunctionKind::#kind(#eval_name),
+                    }
+                }
+            }
+        } else {
+            quote! {}
         };
 
         Ok(quote! {
@@ -84,21 +105,7 @@ impl FunctionAttr {
                 arrow_udf::ffi::#ffi_wrapper(#eval_name, ptr, len, out)
             }
 
-            #[cfg(feature = "global_registry")]
-            #[::arrow_udf::codegen::linkme::distributed_slice(::arrow_udf::sig::SIGNATURES)]
-            fn #sig_name() -> ::arrow_udf::sig::FunctionSignature {
-                use ::arrow_udf::sig::{FunctionSignature, FunctionKind};
-                use ::arrow_udf::codegen::arrow_schema::{self, TimeUnit, IntervalUnit, Field};
-
-                let args: Vec<Field> = vec![#(#args),*];
-                FunctionSignature {
-                    name: #name.into(),
-                    arg_types: args.into(),
-                    variadic: #variadic,
-                    return_type: #ret,
-                    function: FunctionKind::#kind(#eval_name),
-                }
-            }
+            #global_registry
         })
     }
 

--- a/arrow-udf/CHANGELOG.md
+++ b/arrow-udf/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `global_registry` feature.
+
 ## [0.5.2] - 2024-12-24
 
 ### Fixed

--- a/arrow-udf/Cargo.toml
+++ b/arrow-udf/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["wasm"]
 license = "Apache-2.0"
 
 [features]
-global_registry = ["linkme"]
+global_registry = ["linkme", "arrow-udf-macros/global_registry"]
 
 [dependencies]
 arrow-arith.workspace = true

--- a/arrow-udf/README.md
+++ b/arrow-udf/README.md
@@ -110,6 +110,7 @@ If you want to lookup functions by signature, you can enable the `global_registr
 ```toml
 [dependencies]
 arrow-udf = { version = "0.3", features = ["global_registry"] }
+linkme = "0.3"
 ```
 
 Each function will be registered in a global registry when it is defined.

--- a/arrow-udf/README.md
+++ b/arrow-udf/README.md
@@ -110,7 +110,6 @@ If you want to lookup functions by signature, you can enable the `global_registr
 ```toml
 [dependencies]
 arrow-udf = { version = "0.3", features = ["global_registry"] }
-linkme = "0.3"
 ```
 
 Each function will be registered in a global registry when it is defined.


### PR DESCRIPTION
Correctly propagate `global_registry` feature to the macro crate.

Set custom linkme path so that user no longer need to import `linkme`.
https://github.com/dtolnay/linkme/blob/ead19cc7486029eaf0bba3961a79b8524886c6d1/tests/custom_linkme_path.rs#L9