### PR TITLE
fix: restore to main interpreter before creating sub-interpreter

### DIFF
--- a/arrow-udf-python/CHANGELOG.md
+++ b/arrow-udf-python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug that causes `RuntimeError('unable to get sys.modules')` when creating the second `SubInterpreter`.
+
 ## [0.4.0] - 2024-10-10
 
 ### Changed


### PR DESCRIPTION
Fix a segmentation fault encountered in RisingWave: https://github.com/risingwavelabs/risingwave/issues/20527