### PR TITLE
refactor: Remove SubInterpreter and bump pyo3 to 0.24

### DIFF
--- a/arrow-udf-runtime/Cargo.toml
+++ b/arrow-udf-runtime/Cargo.toml
@@ -42,7 +42,7 @@ wasmtime = { version = "27", optional = true }
 genawaiter2 = { version = "0.100.1", optional = true }
 tempfile = { version = "3", optional = true }
 
-pyo3 = { version = "0.21", features = ["gil-refs"], optional = true }
+pyo3 = { version = "0.24.1", optional = true }
 
 atomic-time = { version = "0.1", optional = true }
 rquickjs = { version = "0.6", features = [
@@ -60,7 +60,7 @@ tonic = { version = "0.12", optional = true }
 tracing = { version = "0.1", optional = true }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.21", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.24", features = ["resolve-config"] }
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }

--- a/arrow-udf-runtime/src/javascript/mod.rs
+++ b/arrow-udf-runtime/src/javascript/mod.rs
@@ -381,8 +381,8 @@ impl Runtime {
     /// optionally, the code can define:
     ///
     /// - `finish(state) -> value`: Get the result of the aggregate function.
-    ///     If not defined, the state is returned as the result.
-    ///     In this case, `output_type` must be the same as `state_type`.
+    ///   If not defined, the state is returned as the result.
+    ///   In this case, `output_type` must be the same as `state_type`.
     /// - `retract(state, *args) -> state`: Retract a value from the state, returning the updated state.
     /// - `merge(state, state) -> state`: Merge two states, returning the merged state.
     ///

--- a/arrow-udf-runtime/src/python/interpreter.rs
+++ b/arrow-udf-runtime/src/python/interpreter.rs
@@ -12,86 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! High-level API for Python sub-interpreters.
+//! High-level API for Python interpreters.
+//!
+//! # Notes
+//!
+//! Previously, we used `PyO3` to create a new Python sub-interpreter. However,
+//! due to limitations in the new `PyO3` API, we can no longer implement it as we
+//! did before.
+//! For now, we are deprecating this module but forwarding the `PyO3` API to the
+//! new one to ensure a smoother migration path.
+//! You may choose to refactor this module to use `PyO3` directly at a later time.
 
-use std::{ffi::CStr, sync::Once};
+use std::{ffi::CString, sync::Once};
 
-#[allow(deprecated)]
-use pyo3::GILPool;
-use pyo3::{ffi::*, PyErr, Python};
+use pyo3::{PyErr, Python};
 
-/// A Python sub-interpreter with its own GIL.
+/// A Python interpreter with its own GIL.
 #[derive(Debug)]
-pub struct SubInterpreter {
-    // XXX: according to the Python C API, the thread state is only valid in the thread that created it.
-    //      but we allow the `SubInterpreter` to be sent to other threads for practical reasons.
-    state: *mut PyThreadState,
-}
-
-// XXX: not sure if this is safe
-unsafe impl Send for SubInterpreter {}
-unsafe impl Sync for SubInterpreter {}
+pub struct Interpreter;
 
 static GLOBAL_INIT: Once = Once::new();
 
-impl SubInterpreter {
+impl Interpreter {
     /// Create a new sub-interpreter.
     pub fn new() -> Result<Self, PyError> {
         GLOBAL_INIT.call_once_force(|_| {
             // use call_once_force because if initialization panics, it's okay to try again
 
-            // see `pyo3::prepare_freethreaded_python`
-            unsafe {
-                if Py_IsInitialized() == 0 {
-                    Py_InitializeEx(0);
-                    // now the current thread state is of the main interpreter
-                    // and the GIL of it is held
-
-                    // release the GIL
-                    PyEval_SaveThread();
-                }
-            }
-
-            // XXX: import the `decimal` module in the main interpreter before creating any sub-interpreters.
+            // XXX: import the `decimal` module in the interpreter before calling anything else
             //      otherwise it will cause `SIGABRT: pointer being freed was not allocated`
             //      when importing decimal in the second sub-interpreter.
             Python::with_gil(|py| {
-                py.import_bound("decimal").unwrap();
+                py.import("decimal").unwrap();
             });
         });
 
-        // switch to the main interpreter and acquire its GIL, because `Py_NewInterpreterFromConfig`
-        // requires the GIL to be held before calling.
-        unsafe {
-            let state = PyInterpreterState_ThreadHead(PyInterpreterState_Main());
-            PyEval_RestoreThread(state);
-        }
-
-        // reference: https://github.com/PyO3/pyo3/blob/9a36b5078989a7c07a5e880aea3c6da205585ee3/examples/sequential/tests/test.rs
-        let config = PyInterpreterConfig {
-            use_main_obmalloc: 0,
-            allow_fork: 0,
-            allow_exec: 0,
-            allow_threads: 0,
-            allow_daemon_threads: 0,
-            check_multi_interp_extensions: 1,
-            gil: PyInterpreterConfig_OWN_GIL, // each sub-interpreter has its own GIL
-        };
-        let mut state: *mut PyThreadState = std::ptr::null_mut();
-        let status: PyStatus = unsafe { Py_NewInterpreterFromConfig(&mut state, &config) };
-        if unsafe { PyStatus_IsError(status) } == 1 {
-            let msg = unsafe { CStr::from_ptr(status.err_msg) };
-            return Err(anyhow::anyhow!(
-                "failed to create sub-interpreter: {}",
-                msg.to_string_lossy()
-            )
-            .into());
-        }
-        // after success of `Py_NewInterpreterFromConfig`, the current thread state is set to the new sub-interpreter
-        assert_eq!(state, unsafe { PyThreadState_Get() });
-        // release the GIL of the new sub-interpreter
-        unsafe { PyEval_SaveThread() };
-        Ok(Self { state })
+        Ok(Self)
     }
 
     /// Run a closure in the sub-interpreter.
@@ -103,45 +59,22 @@ impl SubInterpreter {
     where
         F: for<'py> FnOnce(Python<'py>) -> Result<R, PyError>,
     {
-        // switch to the sub-interpreter and acquire GIL
-        unsafe { PyEval_RestoreThread(self.state) };
-
-        // Safety: the GIL is already held
-        // this pool is used to increment the internal GIL count of pyo3.
-        #[allow(deprecated)]
-        let pool = unsafe { GILPool::new() };
-        let ret = f(pool.python());
-        drop(pool);
-
-        // release the GIL
-        unsafe { PyEval_SaveThread() };
-        ret
+        Python::with_gil(f)
     }
 
     /// Run Python code in the sub-interpreter.
     pub fn run(&self, code: &str) -> Result<(), PyError> {
-        self.with_gil(|py| py.run_bound(code, None, None).map_err(|e| e.into()))
+        let code = CString::new(code).unwrap();
+        self.with_gil(|py| py.run(&code, None, None).map_err(|e| e.into()))
     }
 }
 
-impl Drop for SubInterpreter {
-    fn drop(&mut self) {
-        unsafe {
-            // switch to the sub-interpreter
-            PyEval_RestoreThread(self.state);
-            assert_eq!(self.state, PyThreadState_GET());
-            // destroy the sub-interpreter
-            Py_EndInterpreter(self.state);
-        }
-    }
-}
-
-/// The error type for Python sub-interpreters.
+/// The error type for Python interpreters.
 ///
 /// This type is a wrapper around `anyhow::Error`. The special thing is that
 /// when it comes from `PyErr`, only the error message is retained, and the
 /// original type is discarded. This is to avoid the problem of `PyErr` being
-/// dropped outside the sub-interpreter.
+/// dropped outside the interpreter.
 #[derive(Debug)]
 pub struct PyError {
     anyhow: anyhow::Error,

--- a/arrow-udf-runtime/src/python/mod.rs
+++ b/arrow-udf-runtime/src/python/mod.rs
@@ -14,20 +14,10 @@
 
 #![doc = include_str!("README.md")]
 
-// Notice for developers:
-// This library uses the sub-interpreter and per-interpreter GIL introduced in Python 3.12
-// to support concurrent execution of different functions in multiple threads.
-// However, pyo3 has not yet safely supported sub-interpreter. We use the raw FFI API of pyo3 to implement sub-interpreter.
-// Therefore, special attention is needed:
-// **All PyObject created in a sub-interpreter must be destroyed in the same sub-interpreter.**
-// Otherwise, it will cause a crash the next time Python is called.
-// Special attention is needed for PyErr in PyResult.
-// Remember to convert `PyErr` using the `pyerr_to_anyhow` function before passing it out of the sub-interpreter.
-
 use crate::into_field::IntoField;
 use crate::CallMode;
 
-use self::interpreter::SubInterpreter;
+use self::interpreter::Interpreter;
 use anyhow::{bail, Context, Result};
 use arrow_array::builder::{ArrayBuilder, Int32Builder, StringBuilder};
 use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch};
@@ -35,6 +25,7 @@ use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use pyo3::types::{PyAnyMethods, PyIterator, PyModule, PyTuple};
 use pyo3::{Py, PyObject};
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -72,7 +63,7 @@ mod pyarrow;
 /// [`merge`]: Runtime::merge
 /// [`finish`]: Runtime::finish
 pub struct Runtime {
-    interpreter: SubInterpreter,
+    interpreter: Interpreter,
     functions: HashMap<String, Function>,
     aggregates: HashMap<String, Aggregate>,
     converter: pyarrow::Converter,
@@ -150,7 +141,7 @@ impl Builder {
 
     /// Build the `Runtime`.
     pub fn build(self) -> Result<Runtime> {
-        let interpreter = SubInterpreter::new()?;
+        let interpreter = Interpreter::new()?;
         interpreter.run(
             r#"
 # internal use for json types
@@ -295,7 +286,9 @@ impl Runtime {
         handler: &str,
     ) -> Result<()> {
         let function = self.interpreter.with_gil(|py| {
-            Ok(PyModule::from_code_bound(py, code, name, name)?
+            let code = CString::new(code).unwrap();
+            let name = CString::new(name).unwrap();
+            Ok(PyModule::from_code(py, &code, &name, &name)?
                 .getattr(handler)?
                 .into())
         })?;
@@ -326,8 +319,8 @@ impl Runtime {
     /// optionally, the code can define:
     ///
     /// - `finish(state) -> value`: Get the result of the aggregate function.
-    ///     If not defined, the state is returned as the result.
-    ///     In this case, `output_type` must be the same as `state_type`.
+    ///   If not defined, the state is returned as the result.
+    ///   In this case, `output_type` must be the same as `state_type`.
     /// - `retract(state, *args) -> state`: Retract a value from the state, returning the updated state.
     /// - `merge(state, state) -> state`: Merge two states, returning the merged state.
     ///
@@ -369,7 +362,9 @@ impl Runtime {
         code: &str,
     ) -> Result<()> {
         let aggregate = self.interpreter.with_gil(|py| {
-            let module = PyModule::from_code_bound(py, code, name, name)?;
+            let c_code = CString::new(code).unwrap();
+            let c_name = CString::new(name).unwrap();
+            let module = PyModule::from_code(py, &c_code, &c_name, &c_name)?;
             Ok(Aggregate {
                 state_field: state_type.into_field(name).into(),
                 output_field: output_type.into_field(name).into(),
@@ -447,7 +442,7 @@ impl Runtime {
                     let pyobj = self.converter.get_pyobject(py, field, column, i)?;
                     row.push(pyobj);
                 }
-                let args = PyTuple::new_bound(py, row.drain(..));
+                let args = PyTuple::new(py, row.drain(..))?;
                 match function.function.call1(py, args) {
                     Ok(result) => results.push(result),
                     Err(e) => {
@@ -585,7 +580,7 @@ impl Runtime {
                     let pyobj = self.converter.get_pyobject(py, field, column, i)?;
                     row.push(pyobj);
                 }
-                let args = PyTuple::new_bound(py, row.drain(..));
+                let args = PyTuple::new(py, row.drain(..))?;
                 state = aggregate.accumulate.call1(py, args)?;
             }
             let output = self
@@ -645,7 +640,7 @@ impl Runtime {
                     let pyobj = self.converter.get_pyobject(py, field, column, i)?;
                     row.push(pyobj);
                 }
-                let args = PyTuple::new_bound(py, row.drain(..));
+                let args = PyTuple::new(py, row.drain(..))?;
                 let func = if ops.is_valid(i) && ops.value(i) {
                     retract
                 } else {
@@ -685,7 +680,7 @@ impl Runtime {
                 let state2 = self
                     .converter
                     .get_pyobject(py, &aggregate.state_field, states, i)?;
-                let args = PyTuple::new_bound(py, [state, state2]);
+                let args = PyTuple::new(py, [state, state2])?;
                 state = merge.call1(py, args)?;
             }
             let output = self
@@ -723,7 +718,7 @@ impl Runtime {
                 let state = self
                     .converter
                     .get_pyobject(py, &aggregate.state_field, states, i)?;
-                let args = PyTuple::new_bound(py, [state]);
+                let args = PyTuple::new(py, [state])?;
                 let result = finish.call1(py, args)?;
                 results.push(result);
             }
@@ -738,7 +733,7 @@ impl Runtime {
 
 /// An iterator over the result of a table function.
 pub struct RecordBatchIter<'a> {
-    interpreter: &'a SubInterpreter,
+    interpreter: &'a Interpreter,
     input: &'a RecordBatch,
     function: &'a Function,
     schema: SchemaRef,
@@ -784,10 +779,10 @@ impl RecordBatchIter<'_> {
                         let val = self.converter.get_pyobject(py, field, column, self.row)?;
                         row.push(val);
                     }
-                    let args = PyTuple::new_bound(py, row.drain(..));
+                    let args = PyTuple::new(py, row.drain(..))?;
                     match self.function.function.bind(py).call1(args) {
                         Ok(result) => {
-                            let iter = result.iter()?.into();
+                            let iter = result.try_iter()?.into();
                             self.generator.insert(iter)
                         }
                         Err(e) => {


### PR DESCRIPTION
This PR will remove SubInterpreter and bump pyo3 to 0.24 as we discussed before.

---

The new pyo3 doesn't allow us to hack the internal lock counter anymore. There is no way for us to make `SubInterpreter` work. And keep pinning on the old version of pyo3 makes us failed to work with python 3.13.

Thus we decided to remove SubInterpreter entirely.