### PR TITLE
fix: lock pyarrow to v19 to avoid the maps_as_pydicts bug

### DIFF
--- a/arrow-udf-remote/python/CHANGELOG.md
+++ b/arrow-udf-remote/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-05-09
+
+### Fixed
+
+- Lock `pyarrow` version to `19` to avoid the `maps_as_pydicts` bug ([#129](https://github.com/arrow-udf/arrow-udf/issues/129)).
+
 ## [0.3.0] - 2025-02-12
 
 ### Added

--- a/arrow-udf-remote/python/pyproject.toml
+++ b/arrow-udf-remote/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arrow-udf"
-version = "0.3.0"
+version = "0.3.1"
 authors = [{ name = "RisingWave Labs" }]
 description = "A user-defined function framework for Apache Arrow"
 readme = "README.md"

--- a/arrow-udf-remote/python/pyproject.toml
+++ b/arrow-udf-remote/python/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.8"
-dependencies = ["pyarrow"]
+dependencies = ["pyarrow<20"]
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
Signed-off-by: Richard Chien <stdrc@outlook.com>

Fixes #129